### PR TITLE
Scrum-110: Add equipment page functionality, minor css

### DIFF
--- a/backend/models/Item.js
+++ b/backend/models/Item.js
@@ -26,11 +26,11 @@ const itemSchema = new mongoose.Schema({
         },
         checkin: {
             type: Date,
-            default: '3'
+            default: '' // Set default date to January 1, 2024
         },
         checkout: {
             type: Date,
-            default: '3'
+            default: '' // Set default date to January 1, 2024
         },
     }],
 });

--- a/backend/routes/itemRoutes.js
+++ b/backend/routes/itemRoutes.js
@@ -1,18 +1,19 @@
 const express = require('express');
-const { 
+const {
     pickUpItem,
     removeItem,
+    removeSingularItem,
     returnItem,
     createGlobalItem,
     getAllGlobalEquipment,
     getItemByName,
-    createSingleItem, 
-    getSingleItemsByClassCode, 
-    purchaseSingleItem, 
-    returnSingleItem, 
-    createBundleItem, 
-    getBundleItemsByClassCode, 
-    purchaseBundleItem, 
+    createSingleItem,
+    getSingleItemsByClassCode,
+    purchaseSingleItem,
+    returnSingleItem,
+    createBundleItem,
+    getBundleItemsByClassCode,
+    purchaseBundleItem,
     returnBundleItem,
     toggleRepairStatus,
     toggleHideStatus
@@ -21,20 +22,21 @@ const {
 const router = express.Router();
 
 // Route to create global items in the equipment checkout center
-router.post('/item', createGlobalItem); 
+router.post('/item', createGlobalItem);
 
 // Route to get all global equipment
 router.get('/items', getAllGlobalEquipment);
 
 // Route to get a specific item by item name
-router.get('/item/:itemName', getItemByName); 
+router.get('/item/:itemName', getItemByName);
 
 // Routes for picking up and returning items
 router.post('/pickup-item/:itemName/:itemId', pickUpItem);
 router.post('/return-item/:itemName/:itemId', returnItem);
 
 // Route to remove an item from the database
-router.delete('/item/:itemName', removeItem); 
+router.delete('/item/:itemName', removeItem);
+router.delete('/deleteItemId/:itemId', removeSingularItem);
 
 // Routes for single items
 router.post('/single-item', createSingleItem);
@@ -48,12 +50,10 @@ router.get('/bundle-items/:classCode', getBundleItemsByClassCode);
 router.post('/purchase-bundle/:bundleId', purchaseBundleItem);
 router.post('/return-bundle/:bundleId', returnBundleItem);
 
-// Route to toggle repair status by itemId
-// @route PATCH /item/:itemId/repair
-router.patch('/item/:itemId/repair', toggleRepairStatus);
+// Toggle repair status of item
+router.patch('/item/itemId/:itemId/repair', toggleRepairStatus);
 
-// Route to toggle hide status by itemId
-// @route PATCH /item/:itemId/hide
-router.patch('/item/:itemId/hide', toggleHideStatus);
+// Toggle hide status of item
+router.patch('/item/itemId/:itemId/hide', toggleHideStatus);
 
 module.exports = router;

--- a/frontend/src/components/Button/BackButton/BackButton.css
+++ b/frontend/src/components/Button/BackButton/BackButton.css
@@ -4,7 +4,7 @@
     padding: 10px 70px;
     font-size: 16px;
     border: none;
-    border-radius: 50px;
+    border-radius: 50px; 
     cursor: pointer;
     display: inline-block;
     text-align: center;
@@ -12,5 +12,6 @@
 }
 
 .back-btn:hover {
-    background-color: #2e4a7a;
+    background-color: #2e4a7a; 
 }
+

--- a/frontend/src/components/Button/EditButton/EditButton.css
+++ b/frontend/src/components/Button/EditButton/EditButton.css
@@ -1,19 +1,18 @@
 .edit-btn {
     border-radius: 5px;
-    width: 80px;
-    height: 30px;
+    width: 85px;
     background-color: #3361AE;
     border: 2px solid #3361AE;
     color: white;
-    font-size: 15px;
+    font-size: 20px;
     font-weight: 600;
-    padding: 8%;
+    padding: 8px;
     cursor: pointer;
     letter-spacing: 0.5px;
 }
 
 .edit-icon {
-    font-size: 13px;
-    margin-left: 8px;
+    font-size: 16px;
+    margin-left: 4px;
     margin-bottom: 2px;
 }

--- a/frontend/src/components/Button/EditButton/EditButton.css
+++ b/frontend/src/components/Button/EditButton/EditButton.css
@@ -11,7 +11,7 @@
     letter-spacing: 0.5px;
 }
 
-.edit-icon {
+.edit-btn-icon {
     font-size: 16px;
     margin-left: 4px;
     margin-bottom: 2px;

--- a/frontend/src/components/Button/EditButton/EditButton.js
+++ b/frontend/src/components/Button/EditButton/EditButton.js
@@ -1,21 +1,21 @@
 import React from 'react';
 import './EditButton.css';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'; 
-import { faEdit } from '@fortawesome/free-solid-svg-icons'; 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faEdit } from '@fortawesome/free-solid-svg-icons';
 
 const EditButton = ({ isEditMode, toggleEditMode }) => {
-  if (isEditMode) {
-    return null; // Do not render the Edit button in edit mode
-  }
+    if (isEditMode) {
+        return null; // Do not render the Edit button in edit mode
+    }
 
-  return (
-    <div onClick={toggleEditMode}>
-      <button className="edit-btn">
-        Edit
-        <FontAwesomeIcon icon={faEdit} className="edit-icon" />
-      </button>
-    </div>
-  );
+    return (
+        <div onClick={toggleEditMode}>
+            <button className="edit-btn">
+                Edit
+                <FontAwesomeIcon icon={faEdit} className="edit-btn-icon" />
+            </button>
+        </div>
+    );
 };
 
 export default EditButton;

--- a/frontend/src/components/Button/TimeSelectionButton/TimeSelectionButton.css
+++ b/frontend/src/components/Button/TimeSelectionButton/TimeSelectionButton.css
@@ -14,7 +14,6 @@
 .time-button {
     border: 2px solid #0052cc;
     border-radius: 230px;
-    text-align: center;
     padding: 0%;
     display: flex;
     align-items: center;
@@ -36,15 +35,6 @@
     height: 32px;
 }
 
-.react-datepicker__input-container {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-bottom: 10px;
-    margin-top: auto;
-    height: 100%;
-}
-
 .react-datepicker-wrapper {
     border: none;
     align-items: center;
@@ -60,7 +50,7 @@
     border: none;
     cursor: pointer;
     outline: none;
-    height: 100%;
+    padding: 0px;
     text-align: center;
     box-sizing: border-box;
 }

--- a/frontend/src/components/Button/TimeSelectionButton/TimeSelectionButton.js
+++ b/frontend/src/components/Button/TimeSelectionButton/TimeSelectionButton.js
@@ -1,84 +1,107 @@
 import React, { useState, useRef, useEffect } from 'react';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
-import './TimeSelectionButton.css';
-import calendarIcon from '../../../Image/calendar.svg';
+import './TimeSelectionButton.css'
+import calendarIcon from '../../../Image/calendar.svg'
 
-function TimeSelectionButton({ initialPickupDateTime, initialReturnDateTime, onPickupDateTimeChange, onReturnDateTimeChange }) {
-    const [pickupDateTime, setPickupDateTime] = useState(initialPickupDateTime);
-    const [returnDateTime, setReturnDateTime] = useState(initialReturnDateTime);
-    const pickupRef = useRef(null);
-    const returnRef = useRef(null);
+function TimeSelectionButton({initialPickupDateTime, initialReturnDateTime }){
+  const [pickupDateTime, setPickupDateTime] = useState(initialPickupDateTime);
+  const [returnDateTime, setReturnDateTime] = useState(initialReturnDateTime);
+  const pickupRef = useRef(null);
+  const returnRef = useRef(null);
 
-    useEffect(() => {
-        if (initialPickupDateTime) {
-            setPickupDateTime(new Date(initialPickupDateTime));
-        }
-        if (initialReturnDateTime) {
-            setReturnDateTime(new Date(initialReturnDateTime));
-        }
-    }, [initialPickupDateTime, initialReturnDateTime]);
+  useEffect(() => {
+    if (initialPickupDateTime) {
+      setPickupDateTime(new Date(initialPickupDateTime));
+    }
+    if (initialReturnDateTime) {
+      setReturnDateTime(new Date(initialReturnDateTime));
+    }
+  }, [initialPickupDateTime, initialReturnDateTime]);
 
-    const handlePickupChange = (date) => {
-        const newDate = new Date(date);
-        setPickupDateTime(newDate);
-        onPickupDateTimeChange(newDate);  // Call the prop function to notify the parent
-        if (newDate >= returnDateTime) {
-            const newReturnDateTime = new Date(newDate.getTime() + 15 * 60000);
-            setReturnDateTime(newReturnDateTime);
-            onReturnDateTimeChange(newReturnDateTime); // Adjust the return time if necessary
-        }
-    };
+  const handlePickupChange = (date) => {
+    const newDate = new Date(date);
+    setPickupDateTime(newDate);
+    if (newDate >= returnDateTime) {
+      setReturnDateTime(new Date(newDate.getTime() + 15 * 60000)); 
+    }
+  };
 
-    const handleReturnChange = (date) => {
-        const newDate = new Date(date);
-        setReturnDateTime(newDate);
-        onReturnDateTimeChange(newDate); // Call the prop function to notify the parent
-    };
+  const handleReturnChange = (date) => {
+    setReturnDateTime(date);
+  };
 
-    const openPickupCalendar = () => {
-        pickupRef.current.setOpen(true);
-    };
+  const getMinReturnDateTime = (selectedDate) => {
+    if (pickupDateTime.toDateString() === returnDateTime.toDateString()) {
+      if (new Date().toDateString() === pickupDateTime.toDateString()) {
+        return new Date(Math.max(pickupDateTime.getTime(), new Date().getTime()) + 15 * 60000);
+      }
+      return new Date(pickupDateTime.getTime() + 15 * 60000);
+    } else {
+      const selectedDayStart = new Date(selectedDate.getFullYear(), selectedDate.getMonth(), selectedDate.getDate());
+      return new Date(selectedDayStart);
+    }
+  };
 
-    const openReturnCalendar = () => {
-        returnRef.current.setOpen(true);
-    };
+  function endOfDay(date) {
+    return new Date(date.setHours(23, 45, 0, 0));
+  }
 
-    return (
-        <div className="time-selection-container">
-            <div className="time-selection">
-                <div className="time-button">
-                    <DatePicker
-                        ref={pickupRef}
-                        selected={pickupDateTime}
-                        onChange={handlePickupChange}
-                        dateFormat="h:mm aa, MM/dd"
-                        showTimeSelect
-                        minDate={new Date()}
-                        timeIntervals={15}
-                    />
-                    <div className="icon-container" onClick={openPickupCalendar}>
-                        <img src={calendarIcon} alt="Calendar" className="icon" />
-                    </div>
-                </div>
-                <span>to</span>
-                <div className="time-button">
-                    <DatePicker
-                        ref={returnRef}
-                        selected={returnDateTime}
-                        onChange={handleReturnChange}
-                        dateFormat="h:mm aa, MM/dd"
-                        showTimeSelect
-                        minDate={pickupDateTime}
-                        timeIntervals={15}
-                    />
-                    <div className="icon-container" onClick={openReturnCalendar}>
-                        <img src={calendarIcon} alt="Calendar" className="icon" />
-                    </div>
-                </div>
-            </div>
+  const minTimeForPickup = (selectedDate) => {
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const selectedDayStart = new Date(selectedDate.getFullYear(), selectedDate.getMonth(), selectedDate.getDate());
+    return today.getTime() === selectedDayStart.getTime() ? now : new Date(selectedDayStart);
+  };
+
+
+  const openPickupCalendar = () => {
+    pickupRef.current.setOpen(true);
+  };
+
+  const openReturnCalendar = () => {
+    returnRef.current.setOpen(true);
+  };
+
+  return (
+    <div className="time-selection-container">
+      <div className="time-selection">
+        <div className="time-button">
+          <DatePicker
+              ref={pickupRef}
+              selected={pickupDateTime}
+              onChange={handlePickupChange}
+              dateFormat="h:mm aa, MM/dd"
+              showTimeSelect
+              minDate={new Date()}
+              minTime={minTimeForPickup(pickupDateTime)}
+              maxTime={endOfDay(new Date())}
+              timeIntervals={15}
+          />
+          <div className="icon-container" onClick={openPickupCalendar}>
+            <img src={calendarIcon} alt="Calendar" className="icon" />
+          </div>
         </div>
-    );
+        <span>to</span>
+        <div className="time-button">
+          <DatePicker
+            ref={returnRef}
+            selected={returnDateTime}
+            onChange={handleReturnChange}
+            dateFormat="h:mm aa, MM/dd"
+            showTimeSelect
+            minDate={pickupDateTime}
+            minTime={getMinReturnDateTime(returnDateTime)}
+            maxTime={endOfDay(new Date())}
+            timeIntervals={15}
+          />
+          <div className="icon-container" onClick={openReturnCalendar}>
+            <img src={calendarIcon} alt="Calendar" className="icon" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export default TimeSelectionButton;

--- a/frontend/src/components/Functions/AgGridTable/AgGridTable.css
+++ b/frontend/src/components/Functions/AgGridTable/AgGridTable.css
@@ -11,7 +11,7 @@ html {
 }
 
 .page-container {
-    width: 70vw;
+    width: 80vw;
     height: auto;
     overflow-y: visible;
 }
@@ -56,4 +56,13 @@ html {
 
 .ag-paging-panel {
     background-color: #FFFDF8;
+    color: #3361AE;
+    border-top: transparent;
+    font-size: 20px;
+}
+
+.ag-icon {
+    color: #3361AE;
+    font-weight: bold;
+    font-size: 20px;
 }

--- a/frontend/src/components/Functions/AgGridTable/AgGridTable.css
+++ b/frontend/src/components/Functions/AgGridTable/AgGridTable.css
@@ -25,7 +25,8 @@ html {
     overflow-y: auto;
 }
 
-.ag-header, .ag-advanced-filter-header {
+.ag-header,
+.ag-advanced-filter-header {
     background-color: #FFFDF8;
     border-top: 2px solid #3361AE;
     border-bottom: 2px solid #3361AE;
@@ -40,7 +41,8 @@ html {
     background-color: transparent;
 }
 
-.ag-header-group-cell-label, .ag-cell-label-container {
+.ag-header-group-cell-label,
+.ag-cell-label-container {
     font-size: 24px;
 }
 
@@ -49,7 +51,7 @@ html {
 }
 
 .ag-paging-page-size {
-    display: none; 
+    display: none;
 }
 
 .ag-paging-panel {

--- a/frontend/src/components/Functions/EquipmentTable/EquipmentTable.css
+++ b/frontend/src/components/Functions/EquipmentTable/EquipmentTable.css
@@ -10,3 +10,29 @@
     cursor: pointer;
     letter-spacing: 0.5px;
 }
+
+.equipment-search-bar-edit-container {
+    display: flex;
+    position: relative;
+    margin: 0 0 2px 0;
+    justify-content: space-around;
+    width: 80vw;
+    justify-content: space-between;
+    margin-inline: auto;
+}
+
+.equipment-btn {
+    display: inline-flex;
+    justify-content: space-between;
+    width: 100%;
+    position: relative;
+    margin-top: 20px;
+    margin-left: 10%;
+}
+
+.equipment-bottom-btn-container {
+    display: flex;
+    justify-content: space-between;
+    width: 80vw;
+    position: relative;
+}

--- a/frontend/src/components/Functions/EquipmentTable/EquipmentTable.css
+++ b/frontend/src/components/Functions/EquipmentTable/EquipmentTable.css
@@ -16,7 +16,7 @@
     position: relative;
     margin: 0 0 2px 0;
     justify-content: space-around;
-    width: 80vw;
+    width: 79vw;
     justify-content: space-between;
     margin-inline: auto;
 }

--- a/frontend/src/components/Functions/EquipmentTable/EquipmentTable.css
+++ b/frontend/src/components/Functions/EquipmentTable/EquipmentTable.css
@@ -1,0 +1,12 @@
+.add-new-button {
+    border-radius: 5px;
+    width: 150px;
+    background-color: #3361AE;
+    border: 2px solid #3361AE;
+    color: white;
+    font-size: 20px;
+    font-weight: 600;
+    padding: 8px;
+    cursor: pointer;
+    letter-spacing: 0.5px;
+}

--- a/frontend/src/components/Functions/EquipmentTable/EquipmentTable.js
+++ b/frontend/src/components/Functions/EquipmentTable/EquipmentTable.js
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import AgGridTable from '../AgGridTable/AgGridTable';
-// import { getItems, deleteGlobalItem, updateItem } from '../../../connector.js';
 import { getItems, deleteGlobalItem, toggleRepairStatus, toggleHideStatus } from '../../../connector.js';
 import SearchBar from '../SearchBar/SearchBar';
 import EditButton from '../../Button/EditButton/EditButton';

--- a/frontend/src/components/Functions/EquipmentTable/EquipmentTable.js
+++ b/frontend/src/components/Functions/EquipmentTable/EquipmentTable.js
@@ -6,6 +6,7 @@ import SearchBar from '../SearchBar/SearchBar';
 import EditButton from '../../Button/EditButton/EditButton';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import './EquipmentTable.css';
 
 class EquipmentTable extends Component {
     constructor(props) {
@@ -143,8 +144,7 @@ class EquipmentTable extends Component {
     };
 
     render() {
-        const { isEditMode, toggleEditMode } = this.props;
-        const containerStyles = { gap: isEditMode ? '20%' : '13.5%' };
+        const { isEditMode, toggleEditMode, handleOpenPopup } = this.props;
         // const searchBarStyle = isEditMode ? { marginRight: '20%' } : {};
 
         const columnDefs = [
@@ -238,18 +238,31 @@ class EquipmentTable extends Component {
         ].filter(Boolean);
 
         return (
+
             <>
                 <div className="student-title">
                     <h2>Equipment</h2>
                 </div>
-                <div className="search-bar-edit-container" style={containerStyles}>
+                <div className="search-bar-edit-container">
                     <div className="student-searchbar" >
                         <SearchBar onSearch={this.handleSearch} />
                     </div>
-                    <div className="student-edit">
+
+                    {!isEditMode && (
                         <EditButton isEditMode={isEditMode} toggleEditMode={toggleEditMode} />
-                    </div>
+                    )}
+
+                    {isEditMode && (
+                        <div className="">
+                            <button className="add-new-button" onClick={handleOpenPopup}>
+                                Add New +
+                            </button>
+                        </div>
+                    )}
                 </div>
+
+
+
                 <AgGridTable
                     key={this.state.filteredRecords.length}
                     rowData={this.state.filteredRecords} // Make sure this points to filteredRecords

--- a/frontend/src/components/Functions/EquipmentTable/EquipmentTable.js
+++ b/frontend/src/components/Functions/EquipmentTable/EquipmentTable.js
@@ -240,10 +240,10 @@ class EquipmentTable extends Component {
         return (
 
             <>
-                <div className="student-title">
-                    <h2>Equipment</h2>
+                <div style={{ display: "flex", paddingTop: "100px", justifyContent: "space-between", width: "60%", paddingBottom: "75px" }}>
+                    <h1 style={{ paddingLeft: "16.5%", color: "#3361AE" }}> Equipment </h1>
                 </div>
-                <div className="search-bar-edit-container">
+                <div className="equipment-search-bar-edit-container">
                     <div className="student-searchbar" >
                         <SearchBar onSearch={this.handleSearch} />
                     </div>

--- a/frontend/src/components/Functions/EquipmentTable/EquipmentTable.js
+++ b/frontend/src/components/Functions/EquipmentTable/EquipmentTable.js
@@ -153,7 +153,8 @@ class EquipmentTable extends Component {
             {
                 headerName: "Price",
                 field: "pricePerItem",
-                width: 120,
+                maxWidth: 250,
+                flex: 2,
                 valueFormatter: (params) => {
                     return params.value !== undefined ? `$${params.value.toFixed(2)}` : 'N/A';
                 }
@@ -161,7 +162,8 @@ class EquipmentTable extends Component {
             {
                 headerName: "Checked-in",
                 field: "checkin",
-                width: 250,
+                maxWidth: 300,
+                flex: 2,
                 valueFormatter: (params) => {
                     const dateValue = new Date(params.value);
                     return params.value ? dateValue.toLocaleString('en-US', {
@@ -174,7 +176,7 @@ class EquipmentTable extends Component {
             {
                 headerName: "Checked-out",
                 field: "checkout",
-                width: 250,
+                flex: 2,
                 valueFormatter: (params) => {
                     const dateValue = new Date(params.value);
                     return params.value ? dateValue.toLocaleString('en-US', {
@@ -187,7 +189,8 @@ class EquipmentTable extends Component {
             {
                 headerName: "Repair",
                 field: "repair",
-                width: 200,
+                maxWidth: 200,
+                flex: 2,
                 editable: false, // make the cell non-editable
                 cellRenderer: (params) => {
                     return params.value ? 'Yes' : 'No'; // render 'Yes' or 'No' based on the value

--- a/frontend/src/components/Functions/EquipmentTable/EquipmentTable.js
+++ b/frontend/src/components/Functions/EquipmentTable/EquipmentTable.js
@@ -166,13 +166,9 @@ class EquipmentTable extends Component {
                     const dateValue = new Date(params.value);
                     return params.value ? dateValue.toLocaleString('en-US', {
                         year: 'numeric',
-                        month: 'long',
-                        day: 'numeric',
-                        hour: '2-digit',
-                        minute: '2-digit',
-                        second: '2-digit',
-                        timeZoneName: 'short',
-                    }) : 'N/A';
+                        month: '2-digit',
+                        day: '2-digit',
+                    }).replace(',', '') : 'N/A';
                 }
             },
             {
@@ -183,13 +179,9 @@ class EquipmentTable extends Component {
                     const dateValue = new Date(params.value);
                     return params.value ? dateValue.toLocaleString('en-US', {
                         year: 'numeric',
-                        month: 'long',
-                        day: 'numeric',
-                        hour: '2-digit',
-                        minute: '2-digit',
-                        second: '2-digit',
-                        timeZoneName: 'short',
-                    }) : 'N/A';
+                        month: '2-digit',
+                        day: '2-digit',
+                    }).replace(',', '') : 'N/A';
                 }
             },
             {

--- a/frontend/src/components/Functions/EquipmentTable/EquipmentTable.js
+++ b/frontend/src/components/Functions/EquipmentTable/EquipmentTable.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import AgGridTable from '../AgGridTable/AgGridTable';
 // import { getItems, deleteGlobalItem, updateItem } from '../../../connector.js';
-import { getItems, deleteGlobalItem } from '../../../connector.js';
+import { getItems, deleteGlobalItem, toggleRepairStatus, toggleHideStatus } from '../../../connector.js';
 import SearchBar from '../SearchBar/SearchBar';
 import EditButton from '../../Button/EditButton/EditButton';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -13,13 +13,14 @@ class EquipmentTable extends Component {
         this.state = {
             records: [],
             filteredRecords: [],
-            tempDeletedRows: [],
-            updatedRoles: {},
+            deletedRecords: [],
+            tempToggledRepairs: [],
+            tempToggledHides: [],
             defaultColDef: {
                 sortable: true,
                 resizable: true
             },
-            searchQuery: ''
+            searchQuery: '',
         };
     }
 
@@ -41,43 +42,100 @@ class EquipmentTable extends Component {
                     checkin: itemId.checkin,
                     checkout: itemId.checkout,
                     repair: itemId.repair,
+                    hide: itemId.hide,
                 }))
             );
 
             this.setState({
                 records: transformedRecords,
                 filteredRecords: transformedRecords,
-                tempDeletedRows: [],
-                updatedRoles: {}
             });
         } catch (error) {
             console.error("Error loading records:", error);
         }
     };
 
-    tempDeleteRow = (data) => {
-        this.setState((prevState) => {
-            const updatedRecords = prevState.records.filter(record => record._id !== data._id);
-            const updatedFilteredRecords = prevState.filteredRecords.filter(record => record._id !== data._id);
+    tempDelete = async (data) => {
+        console.log(data);
+        const { filteredRecords, deletedRecords } = this.state;
 
-            return {
-                records: updatedRecords,
-                filteredRecords: updatedFilteredRecords,
-                tempDeletedRows: [...prevState.tempDeletedRows, data._id]
-            };
+        const updatedRecords = filteredRecords.filter(record =>
+            !(record.itemName === data.itemName && record.itemId === data.itemId)
+        );
+
+        this.setState({
+            filteredRecords: updatedRecords,
+            deletedRecords: [...deletedRecords, data],
+        });
+    }
+
+    tempToggleRepair = (data) => {
+        const { filteredRecords, tempToggledRepairs } = this.state;
+
+        // Toggle the repair status for the given item
+        const updatedRecords = filteredRecords.map(record =>
+            record.itemName === data.itemName && record.itemId === data.itemId
+                ? { ...record, repair: !record.repair }
+                : record
+        );
+
+        this.setState({
+            filteredRecords: updatedRecords,
+            tempToggledRepairs: [...tempToggledRepairs, data], // Add to the tempToggledRepairs list
         });
     };
 
-    confirmDeleteRows = async () => {
+    tempToggleHide = (data) => {
+        const { filteredRecords, tempToggledHides } = this.state;
+
+        // Toggle the hide status for the given item
+        const updatedRecords = filteredRecords.map(record =>
+            record.itemName === data.itemName && record.itemId === data.itemId
+                ? { ...record, hide: !record.hide }
+                : record
+        );
+
+        this.setState({
+            filteredRecords: updatedRecords,
+            tempToggledHides: [...tempToggledHides, data], // Add to the tempToggledHides list
+        });
+    };
+
+
+
+    saveChanges = async () => {
+        const { deletedRecords, tempToggledRepairs, tempToggledHides } = this.state;
+
         try {
-            const { tempDeletedRows } = this.state;
-            for (let id of tempDeletedRows) {
-                await deleteGlobalItem(id);
+            // Loop through each deleted record and call deleteGlobalItem
+            for (let record of deletedRecords) {
+                await deleteGlobalItem(record.itemName, record.itemId);
             }
-            this.setState({ tempDeletedRows: [] });
+
+            // Clear the deleted records after successful deletion
+            this.setState({ deletedRecords: [] });
+            console.log("Deletion changes saved successfully!");
+
+            // Loop through the tempToggledRepairs list
+            for (let record of tempToggledRepairs) {
+                const { itemName, itemId } = record;
+                await toggleRepairStatus(itemName, itemId);
+            }
+
+            // Loop through the tempToggledHides list
+            for (let record of tempToggledHides) {
+                const { itemName, itemId } = record;
+                await toggleHideStatus(itemName, itemId);
+            }
+
+            // Clear the toggled lists after successful changes
+            this.setState({ tempToggledRepairs: [], tempToggledHides: [] });
+            console.log("Changes saved successfully!");
+
         } catch (error) {
-            console.error("Error saving deletions:", error);
+            console.error("Error saving changes:", error);
         }
+        this.loadRecords();
     };
 
     handleSearch = (query) => {
@@ -88,48 +146,86 @@ class EquipmentTable extends Component {
         this.setState({ filteredRecords, searchQuery: query });
     };
 
-    handleRoleChange = (id, newRole) => {
-        this.setState(prevState => ({
-            updatedRoles: {
-                ...prevState.updatedRoles,
-                [id]: newRole
-            }
-        }));
-    };
-
-    saveChanges = async () => {
-        try {
-            await this.confirmDeleteRows();
-            this.loadRecords();
-        } catch (error) {
-            console.error("Error saving changes:", error);
-        }
-    };
-
     render() {
         const { isEditMode, toggleEditMode } = this.props;
         const containerStyles = { gap: isEditMode ? '20%' : '13.5%' };
         // const searchBarStyle = isEditMode ? { marginRight: '20%' } : {};
 
-
-
         const columnDefs = [
             { headerName: "ItemID", field: `itemId`, flex: 1 },
             { headerName: "Item Name", field: "itemName", flex: 1 },
-            { headerName: "Price", field: "pricePerItem", flex: 1 },
+            {
+                headerName: "Price",
+                field: "pricePerItem",
+                flex: 1,
+                valueFormatter: (params) => {
+                    return params.value !== undefined ? `$${params.value.toFixed(2)}` : 'N/A';
+                }
+            },
             {
                 headerName: "Checked-in",
                 field: "checkin",
                 flex: 1,
-                valueFormatter: (params) => params.value ? params.value : 'N/A'
+                valueFormatter: (params) => {
+                    const dateValue = new Date(params.value);
+                    return params.value ? dateValue.toLocaleString('en-US', {
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                        second: '2-digit',
+                        timeZoneName: 'short',
+                    }) : 'N/A';
+                }
             },
             {
                 headerName: "Checked-out",
                 field: "checkout",
                 flex: 1,
-                valueFormatter: (params) => params.value ? params.value : 'N/A'
+                valueFormatter: (params) => {
+                    const dateValue = new Date(params.value);
+                    return params.value ? dateValue.toLocaleString('en-US', {
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                        second: '2-digit',
+                        timeZoneName: 'short',
+                    }) : 'N/A';
+                }
             },
-            { headerName: "Repair", field: "repair", flex: 1 },
+            {
+                headerName: "Repair",
+                field: "repair",
+                flex: 1,
+                valueFormatter: (params) => params.value ? 'Yes' : 'No', // Display "Yes" or "No"
+                cellRenderer: isEditMode ? (params) => {
+                    return (
+                        <input
+                            type="checkbox"
+                            checked={params.data.repair}
+                            onChange={() => this.tempToggleRepair(params.data)}
+                        />
+                    );
+                } : null
+            },
+            {
+                headerName: "Hide",
+                field: "hide",
+                flex: 1,
+                valueFormatter: (params) => params.value ? 'Yes' : 'No', // Display "Yes" or "No"
+                cellRenderer: isEditMode ? (params) => {
+                    return (
+                        <input
+                            type="checkbox"
+                            checked={params.data.hide}
+                            onChange={() => this.tempToggleHide(params.data)}
+                        />
+                    );
+                } : null
+            },
 
             isEditMode ? {
                 headerName: "Delete",
@@ -138,7 +234,7 @@ class EquipmentTable extends Component {
                 cellRenderer: params => {
                     return (
                         <button
-                            onClick={() => this.tempDeleteRow(params.data)}
+                            onClick={() => { this.tempDelete(params.data) }}
                             className="trash-icon"
                         >
                             <FontAwesomeIcon icon={faTrash} />
@@ -162,7 +258,8 @@ class EquipmentTable extends Component {
                     </div>
                 </div>
                 <AgGridTable
-                    rowData={this.state.filteredRecords}
+                    key={this.state.filteredRecords.length}
+                    rowData={this.state.filteredRecords} // Make sure this points to filteredRecords
                     columnDefs={columnDefs}
                     defaultColDef={this.state.defaultColDef}
                     domLayout="autoHeight"

--- a/frontend/src/components/Functions/EquipmentTable/EquipmentTable.js
+++ b/frontend/src/components/Functions/EquipmentTable/EquipmentTable.js
@@ -148,12 +148,12 @@ class EquipmentTable extends Component {
         // const searchBarStyle = isEditMode ? { marginRight: '20%' } : {};
 
         const columnDefs = [
-            { headerName: "ItemID", field: `itemId`, flex: 1 },
-            { headerName: "Item Name", field: "itemName", flex: 1 },
+            { headerName: "ItemID", field: "itemId", width: 150, headerClass: 'header-center' },
+            { headerName: "Item Name", field: "itemName", width: 220 },
             {
                 headerName: "Price",
                 field: "pricePerItem",
-                flex: 1,
+                width: 120,
                 valueFormatter: (params) => {
                     return params.value !== undefined ? `$${params.value.toFixed(2)}` : 'N/A';
                 }
@@ -161,7 +161,7 @@ class EquipmentTable extends Component {
             {
                 headerName: "Checked-in",
                 field: "checkin",
-                flex: 1,
+                width: 250,
                 valueFormatter: (params) => {
                     const dateValue = new Date(params.value);
                     return params.value ? dateValue.toLocaleString('en-US', {
@@ -174,7 +174,7 @@ class EquipmentTable extends Component {
             {
                 headerName: "Checked-out",
                 field: "checkout",
-                flex: 1,
+                width: 250,
                 valueFormatter: (params) => {
                     const dateValue = new Date(params.value);
                     return params.value ? dateValue.toLocaleString('en-US', {
@@ -187,7 +187,7 @@ class EquipmentTable extends Component {
             {
                 headerName: "Repair",
                 field: "repair",
-                flex: 1,
+                width: 200,
                 editable: false, // make the cell non-editable
                 cellRenderer: (params) => {
                     return params.value ? 'Yes' : 'No'; // render 'Yes' or 'No' based on the value

--- a/frontend/src/components/Functions/EquipmentTable/EquipmentTable.js
+++ b/frontend/src/components/Functions/EquipmentTable/EquipmentTable.js
@@ -148,29 +148,42 @@ class EquipmentTable extends Component {
         // const searchBarStyle = isEditMode ? { marginRight: '20%' } : {};
 
         const columnDefs = [
-            { headerName: "ItemID", field: "itemId", width: 150, headerClass: 'header-center' },
-            { headerName: "Item Name", field: "itemName", width: 220 },
+            {
+                headerName: "ItemID",
+                field: "itemId",
+                width: 150,
+                headerClass: 'header-center',
+                maxWidth: 225,
+                flex: 1,
+            },
+            {
+                headerName: "Item Name",
+                field: "itemName",
+                width: 250,
+                maxWidth: 250,
+                flex: 1,
+            },
             {
                 headerName: "Price",
                 field: "pricePerItem",
                 maxWidth: 250,
-                flex: 2,
+                flex: 1,
                 valueFormatter: (params) => {
-                    return params.value !== undefined ? `$${params.value.toFixed(2)}` : 'N/A';
+                    return params.value !== undefined ? `$${params.value.toFixed(2)}` : 'Available';
                 }
             },
             {
                 headerName: "Checked-in",
                 field: "checkin",
                 maxWidth: 300,
-                flex: 2,
+                flex: 1,
                 valueFormatter: (params) => {
                     const dateValue = new Date(params.value);
                     return params.value ? dateValue.toLocaleString('en-US', {
                         year: 'numeric',
                         month: '2-digit',
                         day: '2-digit',
-                    }).replace(',', '') : 'N/A';
+                    }).replace(',', '') : 'Available';
                 }
             },
             {
@@ -183,7 +196,7 @@ class EquipmentTable extends Component {
                         year: 'numeric',
                         month: '2-digit',
                         day: '2-digit',
-                    }).replace(',', '') : 'N/A';
+                    }).replace(',', '') : 'Available';
                 }
             },
             {
@@ -243,7 +256,7 @@ class EquipmentTable extends Component {
         return (
 
             <>
-                <div style={{ display: "flex", paddingTop: "100px", justifyContent: "space-between", width: "60%", paddingBottom: "75px" }}>
+                <div style={{ display: "flex", paddingTop: "100px", justifyContent: "space-between", width: "60%", paddingBottom: "25px" }}>
                     <h1 style={{ paddingLeft: "16.5%", color: "#3361AE" }}> Equipment </h1>
                 </div>
                 <div className="equipment-search-bar-edit-container">

--- a/frontend/src/components/Functions/EquipmentTable/EquipmentTable.js
+++ b/frontend/src/components/Functions/EquipmentTable/EquipmentTable.js
@@ -188,16 +188,10 @@ class EquipmentTable extends Component {
                 headerName: "Repair",
                 field: "repair",
                 flex: 1,
-                valueFormatter: (params) => params.value ? 'Yes' : 'No', // Display "Yes" or "No"
-                cellRenderer: isEditMode ? (params) => {
-                    return (
-                        <input
-                            type="checkbox"
-                            checked={params.data.repair}
-                            onChange={() => this.tempToggleRepair(params.data)}
-                        />
-                    );
-                } : null
+                editable: false, // make the cell non-editable
+                cellRenderer: (params) => {
+                    return params.value ? 'Yes' : 'No'; // render 'Yes' or 'No' based on the value
+                }
             },
             {
                 headerName: "Hide",
@@ -206,11 +200,22 @@ class EquipmentTable extends Component {
                 valueFormatter: (params) => params.value ? 'Yes' : 'No', // Display "Yes" or "No"
                 cellRenderer: isEditMode ? (params) => {
                     return (
-                        <input
-                            type="checkbox"
-                            checked={params.data.hide}
-                            onChange={() => this.tempToggleHide(params.data)}
-                        />
+                        <select
+                            value={params.data.hide ? 'Yes' : 'No'}
+                            onChange={(event) => this.tempToggleHide(params.data, event.target.value)}
+                            style={{
+                                width: '50px',                 // Width of the dropdown
+                                padding: '4px',                // Padding inside the dropdown
+                                color: 'white',                // Text color
+                                backgroundColor: '#3361AE',    // Background color
+                                border: 'none',                // No border
+                                borderRadius: '5px',           // Rounded corners
+                                textAlign: 'center'            // Center-align the text
+                            }}
+                        >
+                            <option value="Yes">Yes</option>
+                            <option value="No">No</option>
+                        </select>
                     );
                 } : null
             },

--- a/frontend/src/components/Functions/EquipmentTable/EquipmentTable.js
+++ b/frontend/src/components/Functions/EquipmentTable/EquipmentTable.js
@@ -51,12 +51,10 @@ class EquipmentTable extends Component {
                 filteredRecords: transformedRecords,
             });
         } catch (error) {
-            console.error("Error loading records:", error);
         }
     };
 
     tempDelete = async (data) => {
-        console.log(data);
         const { filteredRecords, deletedRecords } = this.state;
 
         const updatedRecords = filteredRecords.filter(record =>
@@ -114,7 +112,6 @@ class EquipmentTable extends Component {
 
             // Clear the deleted records after successful deletion
             this.setState({ deletedRecords: [] });
-            console.log("Deletion changes saved successfully!");
 
             // Loop through the tempToggledRepairs list
             for (let record of tempToggledRepairs) {
@@ -130,7 +127,6 @@ class EquipmentTable extends Component {
 
             // Clear the toggled lists after successful changes
             this.setState({ tempToggledRepairs: [], tempToggledHides: [] });
-            console.log("Changes saved successfully!");
 
         } catch (error) {
             console.error("Error saving changes:", error);

--- a/frontend/src/components/Functions/SearchBar/SearchBar.css
+++ b/frontend/src/components/Functions/SearchBar/SearchBar.css
@@ -1,5 +1,5 @@
 .search-bar {
-    border: 2px solid #3b5998; 
+    border: 2px solid #3b5998;
     border-radius: 4px;
     background-color: #fff;
     width: 250px;
@@ -7,7 +7,7 @@
 
 .search-input {
     border: none;
-    padding: 4px 0 4px 8px;
+    padding: 8px 0 8px 8px;
     outline: none;
     font-size: 16px;
 }
@@ -16,7 +16,7 @@
     color: #3b5998;
     font-weight: bold;
 }
-  
+
 .search-button {
     background: none;
     border: none;
@@ -24,6 +24,6 @@
     font-size: 15px;
     color: #3b5998;
     padding: 4px;
-    margin-left: 10px;
+    float: right;
+    margin: 5px;
 }
-  

--- a/frontend/src/components/Functions/SearchBar/SearchBar.js
+++ b/frontend/src/components/Functions/SearchBar/SearchBar.js
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 const SearchBar = ({ onSearch }) => {
     const [query, setQuery] = useState('');
+    const [placeholder, setPlaceholder] = useState('Search by Name');
 
     const handleChange = (e) => {
         const newQuery = e.target.value;
@@ -14,13 +15,25 @@ const SearchBar = ({ onSearch }) => {
         }
     };
 
+    const handleFocus = () => {
+        setPlaceholder('');
+    };
+
+    const handleBlur = () => {
+        if (query === '') {
+            setPlaceholder('Search by Name');
+        }
+    };
+
     return (
         <div className="search-bar">
             <input
                 type="text"
-                placeholder="Search by Name"
+                placeholder={placeholder}
                 value={query}
                 onChange={handleChange}
+                onFocus={handleFocus}
+                onBlur={handleBlur}
                 className="search-input"
             />
             <button type="button" className="search-button">

--- a/frontend/src/components/Functions/SearchBar/SearchBar.js
+++ b/frontend/src/components/Functions/SearchBar/SearchBar.js
@@ -19,10 +19,6 @@ const SearchBar = ({ onSearch }) => {
         setPlaceholder('');
     };
 
-    const handleFocus = () => {
-        setPlaceholder('');
-    };
-
     const handleBlur = () => {
         if (query === '') {
             setPlaceholder('Search by Name');

--- a/frontend/src/components/Modal/EquipmentPopup/EquipmentPopup.css
+++ b/frontend/src/components/Modal/EquipmentPopup/EquipmentPopup.css
@@ -33,6 +33,7 @@
     color: #3361AE;
     margin-top: 5px;
 }
+
 .modal-form .form-text {
     margin: 15px 0 10px 0;
     color: #3361AE;
@@ -42,7 +43,7 @@
     margin-bottom: 5px;
 }
 
-.modal-form input{
+.modal-form input {
     width: 500px;
     padding: 8px;
     border-radius: 5px;
@@ -67,7 +68,8 @@
     margin-top: 20px;
 }
 
-.cancel-button, .equipment-popup-submit-button {
+.equipment-cancel-button,
+.equipment-popup-submit-button {
     background-color: transparent;
     color: #3361AE;
     font-weight: 500;
@@ -79,13 +81,31 @@
     font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
 
+.equipment-popup-submit-button:disabled {
+    background-color: #cccccc;
+    /* Light gray color */
+    color: #666666;
+    /* Darker gray text */
+    cursor: not-allowed;
+    /* Show "not-allowed" cursor */
+    border: 1px solid #999999;
+    /* Optional border color */
+}
+
 .equipment-popup-submit-button {
     border: 1px solid #3361AE;
 }
 
 .equipment-popup-submit-button:hover {
     color: white;
-    background-color: #3361AE;;
+    background-color: #3361AE;
+}
+
+.equipment-popup-submit-button:disabled:hover {
+    background-color: #cccccc;
+    color: #666666;
+    cursor: not-allowed;
+    border: 1px solid #999999;
 }
 
 
@@ -110,13 +130,16 @@
     border: 1px solid #3361AE;
 
 }
+
 .mui-textfield .MuiOutlinedInput-notchedOutline {
-    border-color: transparent; 
+    border-color: transparent;
 }
+
 .css-20bmp1-MuiSvgIcon-root {
     color: #3361AE;
 }
 
-.MuiAutocomplete-hasPopupIcon.css-ka7ti6-MuiAutocomplete-root .MuiOutlinedInput-root, .MuiAutocomplete-hasClearIcon.css-ka7ti6-MuiAutocomplete-root .MuiOutlinedInput-root {
+.MuiAutocomplete-hasPopupIcon.css-ka7ti6-MuiAutocomplete-root .MuiOutlinedInput-root,
+.MuiAutocomplete-hasClearIcon.css-ka7ti6-MuiAutocomplete-root .MuiOutlinedInput-root {
     height: 43px;
 }

--- a/frontend/src/components/Modal/EquipmentPopup/EquipmentPopup.js
+++ b/frontend/src/components/Modal/EquipmentPopup/EquipmentPopup.js
@@ -11,6 +11,7 @@ const EquipmentPopup = ({ show, handleClose }) => {
 
     const predefinedItems = ['Camera', 'Light', 'Tripod', 'Microphone'];
 
+    const [uniqueItemNames, setUniqueItemNames] = useState([]); // State for unique item names
     const [databasePrices, setDatabasePrices] = useState([]);
 
     useEffect(() => {
@@ -26,6 +27,8 @@ const EquipmentPopup = ({ show, handleClose }) => {
                 );
 
                 setDatabasePrices(prices);
+                const uniqueNames = [...new Set(prices.map(item => item.itemName))];
+                setUniqueItemNames(uniqueNames);
                 console.log(prices);
             } catch (error) {
                 console.error("Error fetching items:", error);
@@ -105,7 +108,7 @@ const EquipmentPopup = ({ show, handleClose }) => {
                     <div className="dropdown-wrapper">
                         <div className='form-text'>Item Name</div>
                         <Autocomplete
-                            options={predefinedItems}
+                            options={uniqueItemNames}
                             value={itemName}
                             onChange={(event, newValue) => { setItemName(newValue || ''); handleItemNameChange(newValue); }}
                             inputValue={itemName}

--- a/frontend/src/components/Modal/EquipmentPopup/EquipmentPopup.js
+++ b/frontend/src/components/Modal/EquipmentPopup/EquipmentPopup.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import { Autocomplete, TextField } from '@mui/material'; 
-import './EquipmentPopup.css'; 
-import { createGlobalItem } from '../../../connector.js'; 
+import { Autocomplete, TextField } from '@mui/material';
+import './EquipmentPopup.css';
+import { createGlobalItem } from '../../../connector.js';
 
 const EquipmentPopup = ({ show, handleClose }) => {
     const [itemID, setItemID] = useState('');
@@ -16,7 +16,7 @@ const EquipmentPopup = ({ show, handleClose }) => {
         const data = {
             itemName,
             pricePerItem: price,
-            itemIds: [itemID] 
+            itemIds: [itemID]
         };
 
         try {
@@ -33,13 +33,15 @@ const EquipmentPopup = ({ show, handleClose }) => {
         return null;
     }
 
+    const isSubmitDisabled = !itemID || !itemName;
+
     return (
         <div className="modal-overlay">
             <div className="modal-content">
                 <div className="modal-header">
                     <h2 className="header-text">Add a New Equipment</h2>
-                    <button 
-                        className="close-button" 
+                    <button
+                        className="close-button"
                         onClick={handleClose}
                     >
                         <div className='close-button-inner'>
@@ -47,17 +49,17 @@ const EquipmentPopup = ({ show, handleClose }) => {
                         </div>
                     </button>
                 </div>
-                <hr className="header-divider" />
-                
+                {/* <hr className="header-divider" /> */}
+
                 <form onSubmit={handleSubmit} className="modal-form">
                     <div>
                         <div className='form-text'>Item ID</div>
-                        <TextField 
+                        <TextField
                             value={itemID}
-                            onChange={(e) => setItemID(e.target.value)} 
+                            onChange={(e) => setItemID(e.target.value)}
                             fullWidth
-                            className="mui-textfield" 
-                            
+                            className="mui-textfield"
+
                         />
                     </div>
 
@@ -66,14 +68,14 @@ const EquipmentPopup = ({ show, handleClose }) => {
                         <Autocomplete
                             options={predefinedItems}
                             value={itemName}
-                            onChange={(event, newValue) => setItemName(newValue || '')} 
+                            onChange={(event, newValue) => setItemName(newValue || '')}
                             inputValue={itemName}
-                            onInputChange={(event, newInputValue) => setItemName(newInputValue)} 
+                            onInputChange={(event, newInputValue) => setItemName(newInputValue)}
                             renderInput={(params) => (
-                                <TextField 
+                                <TextField
                                     {...params}
                                     fullWidth
-                                    className="mui-textfield" 
+                                    className="mui-textfield"
                                 />
                             )}
                             disableClearable
@@ -94,13 +96,17 @@ const EquipmentPopup = ({ show, handleClose }) => {
                             type="number"
                             fullWidth
                             className="mui-textfield"
-                            inputProps={{ min: "0", step: "0.01" }} 
+                            inputProps={{ min: "0", step: "0.01" }}
                         />
                     </div>
-                    
+
                     <div className="modal-footer">
-                        <button type="button" className="cancel-button" onClick={handleClose}>Cancel</button>
-                        <button type="submit" className="equipment-popup-submit-button">Add Equipment</button>
+                        <button type="button" className="equipment-cancel-button" onClick={handleClose}>Cancel</button>
+                        <button
+                            type="submit"
+                            className="equipment-popup-submit-button"
+                            disabled={isSubmitDisabled}
+                        > Add Equipment</button>
                     </div>
                 </form>
             </div>

--- a/frontend/src/components/Pages/Equipment/Equipment.js
+++ b/frontend/src/components/Pages/Equipment/Equipment.js
@@ -43,14 +43,14 @@ const Equipment = () => {
                 handleOpenPopup={handleOpenPopup}
             />
 
-            <div className="student-btn">
+            <div className="equipment-btn">
                 {isEditMode ? (
-                    <div className="bottom-btn-container">
+                    <div className="equipment-bottom-btn-container">
                         <CancelButton onClick={toggleEditMode} />
                         <SaveButton onClick={handleSave} />
                     </div>
                 ) : (
-                    <div className="bottom-btn-container">
+                    <div className="equipment-bottom-btn-container">
                         <BackButton to="/" />
                     </div>
                 )}

--- a/frontend/src/components/Pages/Equipment/Equipment.js
+++ b/frontend/src/components/Pages/Equipment/Equipment.js
@@ -52,13 +52,13 @@ const Equipment = () => {
                 ) : (
                     <div className="bottom-btn-container">
                         <BackButton to="/" />
+                        <button className="add-new-button" onClick={handleOpenPopup}>
+                            Add New +
+                        </button>
                     </div>
                 )}
             </div>
 
-            <button className="add-new-button" onClick={handleOpenPopup}>
-                Add New +
-            </button>
             <EquipmentPopup show={showPopup} handleClose={handleClosePopup} />
         </div>
     );

--- a/frontend/src/components/Pages/Equipment/Equipment.js
+++ b/frontend/src/components/Pages/Equipment/Equipment.js
@@ -51,7 +51,7 @@ const Equipment = () => {
                     </div>
                 ) : (
                     <div className="equipment-bottom-btn-container">
-                        <BackButton to="/SelectTask" />
+                        <BackButton to="/ViewEquipment" />
                     </div>
                 )}
             </div>

--- a/frontend/src/components/Pages/Equipment/Equipment.js
+++ b/frontend/src/components/Pages/Equipment/Equipment.js
@@ -51,7 +51,7 @@ const Equipment = () => {
                     </div>
                 ) : (
                     <div className="equipment-bottom-btn-container">
-                        <BackButton to="/" />
+                        <BackButton to="/SelectTask" />
                     </div>
                 )}
             </div>

--- a/frontend/src/components/Pages/Equipment/Equipment.js
+++ b/frontend/src/components/Pages/Equipment/Equipment.js
@@ -1,6 +1,5 @@
 import React, { useState, useRef } from 'react';
 import EquipmentPopup from '../../Modal/EquipmentPopup/EquipmentPopup';
-import './Equipment.css';
 
 import BackButton from '../../Button/BackButton/BackButton';
 import CancelButton from '../../Button/CancelButton/CancelButton';
@@ -41,6 +40,7 @@ const Equipment = () => {
                 ref={equipmentTableRef}
                 isEditMode={isEditMode}
                 toggleEditMode={toggleEditMode}
+                handleOpenPopup={handleOpenPopup}
             />
 
             <div className="student-btn">
@@ -52,9 +52,6 @@ const Equipment = () => {
                 ) : (
                     <div className="bottom-btn-container">
                         <BackButton to="/" />
-                        <button className="add-new-button" onClick={handleOpenPopup}>
-                            Add New +
-                        </button>
                     </div>
                 )}
             </div>

--- a/frontend/src/components/Pages/SelectTaskPages/AdminViewEquipment/ViewEquipment.js
+++ b/frontend/src/components/Pages/SelectTaskPages/AdminViewEquipment/ViewEquipment.js
@@ -1,61 +1,62 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import './ViewEquipment.css';
 import { useNavigate } from 'react-router-dom';
 import film from '../../../../Image/filmIcon.svg';
 import Button from '../../../Button/Button';
 
 const ViewEquipment = () => {
-  const navigate = useNavigate();
-  const [selectedClassId, setSelectedClassId] = useState(null);
-  
-  const taskRoutes = {
-    // Add routes after the corresponding page has been created
-      // A: ,
-      // B: ,
-  };
-  
-  const handleConfirms = () => {
-      if (selectedClassId) {
-          navigate(taskRoutes[selectedClassId]);
-      }
-  }
-  const handleBack = () => {
-    navigate('/SelectTask'); 
-  };
+    const navigate = useNavigate();
+    const [selectedClassId, setSelectedClassId] = useState(null);
 
-  const handleClick = (id) => {
-      setSelectedClassId(id);
-  };
+    const taskRoutes = {
+        // Add routes after the corresponding page has been created
+        A: '/equipment'
+        // B: ,
 
-  const classes = [
-      { id: 'A', name: 'Equipment'},
-      { id: 'B', name: 'Damage Report'},
-  ];
+    };
 
-  return (
-      <div className='admin-main-content'>
-        <h1 className="admin-select-class-header">View Equipment</h1>
-        <div className="admin-grid-container">
-          {classes.map((classItem) => (
-              <div key={classItem.id}
-                   className={`admin-class-container ${selectedClassId === classItem.id ? 'selected' : ''}`} // Highlight selected
-                   onClick={() => handleClick(classItem.id)}>
-                <div className="admin-class-icon">
-                  <img className='image' src={film} alt="Class Icon" />
-                </div>
-                <div className={`admin-class-info ${selectedClassId === classItem.id ? 'selected' : ''}`}>
-                  <div className="admin-class-name">{classItem.name}</div>
-                </div>
-              </div>
-          ))}
+    const handleConfirms = () => {
+        if (selectedClassId) {
+            navigate(taskRoutes[selectedClassId]);
+        }
+    }
+    const handleBack = () => {
+        navigate('/SelectTask');
+    };
+
+    const handleClick = (id) => {
+        setSelectedClassId(id);
+    };
+
+    const classes = [
+        { id: 'A', name: 'Equipment' },
+        { id: 'B', name: 'Damage Report' },
+    ];
+
+    return (
+        <div className='admin-main-content'>
+            <h1 className="admin-select-class-header">View Equipment</h1>
+            <div className="admin-grid-container">
+                {classes.map((classItem) => (
+                    <div key={classItem.id}
+                        className={`admin-class-container ${selectedClassId === classItem.id ? 'selected' : ''}`} // Highlight selected
+                        onClick={() => handleClick(classItem.id)}>
+                        <div className="admin-class-icon">
+                            <img className='image' src={film} alt="Class Icon" />
+                        </div>
+                        <div className={`admin-class-info ${selectedClassId === classItem.id ? 'selected' : ''}`}>
+                            <div className="admin-class-name">{classItem.name}</div>
+                        </div>
+                    </div>
+                ))}
+            </div>
+            <div className="btnContainer">
+                <Button type="back" onClick={handleBack}>Back</Button>
+                {selectedClassId && (
+                    <Button type="next" onClick={handleConfirms}>Next</Button>
+                )}
+            </div>
         </div>
-        <div className="btnContainer">
-          <Button type="back" onClick={handleBack}>Back</Button>
-          {selectedClassId && (
-            <Button type="next" onClick={handleConfirms}>Next</Button>
-          )}
-        </div>
-      </div>
     );
 }
 

--- a/frontend/src/connector.js
+++ b/frontend/src/connector.js
@@ -99,21 +99,6 @@ const createGlobalItem = async (data) => {
     }
 };
 
-const updateItem = async (id, role) => {
-    try {
-        // this thing needs to be implemented soon
-        // const res = await axios.put(`${BACKEND_URL}/api/items/${id}`, {
-        //     headers: {
-        //         'Content-Type': 'application/json',
-        //     },
-        // });
-        // return res.data;
-    } catch (error) {
-        console.log(error);
-        throw error;
-    }
-};
-
 const deleteGlobalItem = async (itemName, itemId) => {
     console.log("SOHOS " + itemName + " " + itemId);
     try {
@@ -168,7 +153,6 @@ export {
     getItems,
     createGlobalItem,
     deleteGlobalItem,
-    updateItem,
     toggleRepairStatus,
     toggleHideStatus,
 };

--- a/frontend/src/connector.js
+++ b/frontend/src/connector.js
@@ -114,15 +114,49 @@ const updateItem = async (id, role) => {
     }
 };
 
-const deleteGlobalItem = async (id) => {
+const deleteGlobalItem = async (itemName, itemId) => {
+    console.log("SOHOS " + itemName + " " + itemId);
     try {
-        const res = await axios.delete(`${BACKEND_URL}/api/items/${id}`);
+        const res = await axios.delete(`${BACKEND_URL}/api/deleteItemId/${itemId}/`, {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            data: { itemName },
+        });
         return res.data;
     } catch (error) {
         console.log(error);
         throw error;
     }
 }
+
+const toggleRepairStatus = async (itemName, itemId) => {
+    try {
+        const res = await axios.patch(`${BACKEND_URL}/api/item/itemId/${itemId}/repair`, { itemName }, {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+        return res.data;
+    } catch (error) {
+        console.log(error);
+        throw error;
+    }
+};
+
+const toggleHideStatus = async (itemName, itemId) => {
+    try {
+        const res = await axios.patch(`${BACKEND_URL}/api/item/itemId/${itemId}/hide`, { itemName }, {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+        return res.data;
+    } catch (error) {
+        console.log(error);
+        throw error;
+    }
+};
 
 export {
     getStudents,
@@ -135,4 +169,6 @@ export {
     createGlobalItem,
     deleteGlobalItem,
     updateItem,
+    toggleRepairStatus,
+    toggleHideStatus,
 };


### PR DESCRIPTION
**MERGE scrum-109 FIRST IF NOT YET MERGED**. This branch was created based off of my local scrum-109, so if the branches are merged the other way, things may be missing...? Not sure, but just to be safe.

Equipment page functionality has been added to delete individual items and edit their repair and hide status.

Specific CSS and table appearance, like column width, has not been changed yet in anticipation for a consistent theme to be decided later on, so for now, the table will look like this:
![image](https://github.com/user-attachments/assets/eea20325-bd0e-4209-bba9-ca7c0f074f6d)

**Note:** There may be what seems to be a bug with editing and saving changes for equipment if there are duplicates of the same item type and their id where changes will be reflected for multiple equipment at the same time. When the database is eventually cleaned and each item id and their item name is unique, this bug will not occur, I'm just am not sure if I should have deleted all of them in case someone else were using some of them.