### PR TITLE
Scrum 169: minor fixes to reservation history page

### DIFF
--- a/frontend/src/components/Functions/ReservationHistoryTable/ReservationHistoryTable.js
+++ b/frontend/src/components/Functions/ReservationHistoryTable/ReservationHistoryTable.js
@@ -65,7 +65,7 @@ const ReservationHistoryTable = () => {
     const columnDefs = [
         {
             headerName: "Code",
-            flex: 1,
+            maxWidth: 130,
             cellStyle: { cursor: 'pointer' },
             cellRenderer: params => (
                 <span
@@ -80,7 +80,7 @@ const ReservationHistoryTable = () => {
         {
             headerName: "Pick Up Date",
             field: "checkin",
-            flex: 1,
+            maxWidth: 200,
             valueFormatter: (params) => {
                 const dateValue = new Date(params.value);
                 return params.value ? dateValue.toLocaleString('en-US', {
@@ -93,7 +93,7 @@ const ReservationHistoryTable = () => {
         {
             headerName: "Return Date",
             field: "checkout",
-            flex: 1,
+            maxWidth: 200,
             valueFormatter: (params) => {
                 const dateValue = new Date(params.value);
                 return params.value ? dateValue.toLocaleString('en-US', {

--- a/frontend/src/components/Functions/ReservationHistoryTable/ReservationHistoryTable.js
+++ b/frontend/src/components/Functions/ReservationHistoryTable/ReservationHistoryTable.js
@@ -65,9 +65,17 @@ const ReservationHistoryTable = () => {
     const columnDefs = [
         {
             headerName: "Code",
-            field: "code",
             flex: 1,
             cellStyle: { cursor: 'pointer' },
+            cellRenderer: params => (
+                <span
+                    onClick={() => handleViewReport(params.data.code)}
+                    style={{ color: 'black', textDecoration: 'underline', cursor: 'pointer' }}
+                    className="clickable-text"
+                >
+                    View Code
+                </span>
+            )
         },
         {
             headerName: "Pick Up Date",
@@ -116,19 +124,8 @@ const ReservationHistoryTable = () => {
             flex: 1,
             cellStyle: { cursor: 'pointer', textDecoration: 'underline' },
             valueGetter: () => "View Details",
-            cellRenderer: params => (
-                <span
-                    onClick={() => handleViewReport(params.data.code)}
-                    style={{ color: 'black', textDecoration: 'underline', cursor: 'pointer' }}
-                    className="clickable-text"
-                >
-                    View Details
-                </span>
-            )
-
-            
         }
-            
+
     ];
 
     return (
@@ -145,17 +142,17 @@ const ReservationHistoryTable = () => {
                 domLayout="autoHeight"
                 suppressHorizontalScroll={true}
             />
-    {viewReportId && (
+            {viewReportId && (
                 <BarCodePopup
                     show={!!viewReportId}
-                    orderNumber = {viewReportId}
+                    orderNumber={viewReportId}
                     handleClose={handleCloseModal}
                 />
             )}
-    {viewDamageId && (
+            {viewDamageId && (
                 <StudentViewDamageModal
                     show={!!viewDamageId}
-                    orderNumber = {viewDamageId}
+                    orderNumber={viewDamageId}
                     handleClose={handleCloseModal}
                 />
             )}

--- a/frontend/src/components/Pages/ReservationHistory/ReservationHistory.js
+++ b/frontend/src/components/Pages/ReservationHistory/ReservationHistory.js
@@ -20,7 +20,7 @@ function ReservationHistory() {
 
             <div className="equipment-btn">
                 <div className="rh-bottom-btn-container">
-                    <BackButton to={studentInfo.role === "Admin" ? "/SelectTask" : "/Reservation"} />
+                    <BackButton to={-1} />
 
                     {studentInfo.role === "Admin" && (
                         <button className="rh-btn-send-announcement"> Send Announcement</button>


### PR DESCRIPTION
- fixes reservation history table first column to show the code
- route back button to be instead of the last page user was on

for the style of the buttons for back and announcement buttons, they have the same css styling as the rest of the page already