### PR TITLE
Scrum-197 quick style fix for the enter code box overwritten by the input-style name

### DIFF
--- a/frontend/src/components/Pages/EnterCode/EnterCode.css
+++ b/frontend/src/components/Pages/EnterCode/EnterCode.css
@@ -27,7 +27,7 @@
     color: #3361AE;
 }
 
-.input-field {
+.input-fieldCode {
     width: 85%; 
     padding: 10px;
     border: 2px solid white; 

--- a/frontend/src/components/Pages/EnterCode/EnterCode.js
+++ b/frontend/src/components/Pages/EnterCode/EnterCode.js
@@ -58,7 +58,7 @@ const EnterCode = () => {
             <div className="enterCodeContainer">
                 <h1 className="enterCodeTitle">Enter Class Code</h1>
                 <input
-                    className="input-field"
+                    className="input-fieldCode"
                     type="text"
                     value={codeInput}
                     onChange={handleInputChange}


### PR DESCRIPTION
Fixed the styling of the enterCode box that was accidently overwritten with same input-style css name 